### PR TITLE
feat: 닉네임 중복 검증 추가

### DIFF
--- a/src/main/java/com/memoryseal/memorysealbackend/domain/user/controller/UserController.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/user/controller/UserController.java
@@ -54,9 +54,12 @@ public class    UserController {
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                     examples = @ExampleObject(name = "사용자를 찾을 수 없음", value = "{\"status\": \"404\", \"error\": \"USER_NOT_FOUND\", \"message\": \"존재하지 않는 사용자 입니다.\", \"path\": \"/users/sign-up\"}"))),
-            @ApiResponse(responseCode = "409", description = "이미 온보딩 완료된 사용자",
+            @ApiResponse(responseCode = "409", description = "1. 이미 온보딩 완료된 사용자 \t\n 2. 이미 사용중인 닉네임",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                    examples = @ExampleObject(name = "이미 온보딩 완료된 사용자", value = "{\"status\": \"409\", \"error\": \"ALREADY_ONBOARDED\", \"message\": \"이미 온보딩이 완료된 유저입니다.\", \"path\": \"/users/sign-up\"}")))
+                    examples = {
+                            @ExampleObject(name = "이미 온보딩 완료된 사용자", value = "{\"status\": \"409\", \"error\": \"ALREADY_ONBOARDED\", \"message\": \"이미 온보딩이 완료된 유저입니다.\", \"path\": \"/users/sign-up\"}"),
+                            @ExampleObject(name = "이미 사용중인 닉네임", value = "{\"status\": \"409\", \"error\": \"DUPLICATE_NICKNAME\", \"message\": \"이미 사용 중인 닉네임입니다.\", \"path\": \"/users/sign-up\"}")
+                    }))
     })
     @Operation(summary = "온보딩")
     public ResponseEntity<UserResponseDto> signUpUser(
@@ -102,7 +105,10 @@ public class    UserController {
             @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                    examples = @ExampleObject(name = "사용자를 찾을 수 없음", value = "{\"status\": \"404\", \"error\": \"USER_NOT_FOUND\", \"message\": \"존재하지 않는 사용자 입니다.\", \"path\": \"/users/{userId}\"}")))
+                    examples = @ExampleObject(name = "사용자를 찾을 수 없음", value = "{\"status\": \"404\", \"error\": \"USER_NOT_FOUND\", \"message\": \"존재하지 않는 사용자 입니다.\", \"path\": \"/users/{userId}\"}"))),
+            @ApiResponse(responseCode = "409", description = "이미 사용중인 닉네임",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(name = "이미 사용중인 닉네임", value = "{\"status\": \"409\", \"error\": \"DUPLICATE_NICKNAME\", \"message\": \"이미 사용 중인 닉네임입니다.\", \"path\": \"/users/{userId}\"}")))
     })
     @Operation(summary = "유저 정보 수정", requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = false))
     public ResponseEntity<UserResponseDto> updateUser(

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/user/repository/UserJpaRepository.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/user/repository/UserJpaRepository.java
@@ -14,4 +14,7 @@ public interface UserJpaRepository extends JpaRepository<User,Long> {
     Optional<User> findByProviderAndProviderIdAndUserActiveStatus(String provider, String providerId, Boolean userActiveStatus);
     Boolean existsByProviderAndProviderIdAndUserActiveStatus(String provider, String providerId, Boolean userActiveStatus);
     boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
+
+    boolean existsByNicknameAndIdNot(String nickname, Long id);
 }

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/user/service/UserService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/user/service/UserService.java
@@ -58,11 +58,15 @@ public class UserService {
             throw new AuthException(ErrorCode.ALREADY_ONBOARDED);
         }
 
-        user.setNickname(nickname);
+        if(userJpaRepository.existsByNickname(nickname)) {
+            throw new AuthException(ErrorCode.DUPLICATE_NICKNAME);
+        }
 
         if(profileImage != null && !profileImage.isEmpty()) {
             s3Service.uploadProfileImage(profileImage, user.getId());
         }
+
+        user.setNickname(nickname);
 
         user.setIsOnboarding(true);
 
@@ -97,6 +101,7 @@ public class UserService {
         return UserDetailResponseDto.toDto(user);
     }
 
+    @Transactional
     public UserResponseDto updateMyDetail(String nickname, MultipartFile file) throws IOException {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if(authentication == null || !authentication.isAuthenticated()) {
@@ -114,6 +119,9 @@ public class UserService {
         }
         User user = userJpaRepository.findById(currentUserId).orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
         if(nickname != null && !nickname.isBlank()) {
+            if(userJpaRepository.existsByNicknameAndIdNot(nickname, currentUserId)) {
+                throw new AuthException(ErrorCode.DUPLICATE_NICKNAME);
+            }
             user.setNickname(nickname);
         }
 

--- a/src/main/java/com/memoryseal/memorysealbackend/global/error/ErrorCode.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/global/error/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     ALREADY_REQUESTED(HttpStatus.CONFLICT, "이미 공동작업자 요청을 보냈습니다."),
     ALREADY_CONTRIBUTOR(HttpStatus.CONFLICT, "이미 공동작업자로 등록이 완료된 사용자입니다."),
     ALREADY_ONBOARDED(HttpStatus.CONFLICT, "이미 온보딩이 완료된 유저입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),


### PR DESCRIPTION
## 변경 사항
- UserJpaRepository에 existsByNickname, existsByNicknameAndIdNot 메서드 추가
- ErrorCode에 DUPLICATE_NICKNAME 케이스 추가
- 온보딩 api 닉네임 중복 검증 적용
- 유저 정보 수정 api 닉네임 중복 검증 적용 (본인 닉네임 제외)