### PR TITLE
fix: 타임캡슐 상세 조회시 메인 이미지 값과 상태가 없던 이슈 수정

### DIFF
--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleResponseDto.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleResponseDto.java
@@ -2,6 +2,7 @@ package com.memoryseal.memorysealbackend.domain.time_capsule.controller.dto.res;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.memoryseal.memorysealbackend.domain.time_capsule.entity.TimeCapsule;
+import com.memoryseal.memorysealbackend.domain.time_capsule.entity.TimeCapsuleStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,7 +32,9 @@ public class TimeCapsuleResponseDto {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
     private LocalDateTime openedAt;
 
-    private Boolean timeCapsuleActiveStatus;
+    private String mainImageUrl;
+
+    private TimeCapsuleStatus timeCapsuleStatus;
 
     public static TimeCapsuleResponseDto toDto(TimeCapsule timeCapsule) {
         if (timeCapsule == null) {
@@ -42,7 +45,8 @@ public class TimeCapsuleResponseDto {
                     .description(timeCapsule.getDescription())
                     .buriedAt(timeCapsule.getBuriedAt())
                     .openedAt(timeCapsule.getOpenedAt())
-                    .timeCapsuleActiveStatus(timeCapsule.getTimeCapsuleActiveStatus())
+                    .mainImageUrl(timeCapsule.getMainImage().getFileUrl())
+                    .timeCapsuleStatus(timeCapsule.getTimeCapsuleStatus())
                     .build();
         }
     }


### PR DESCRIPTION
## 변경 사항
- timeCapsuleResponseDto의 timeCapsuleActiveStatus 삭제
- timeCapsuleResponseDto에 mainImageUrl과 timeCapsuleStatus 추가