### PR TITLE
refactor: 로그인과 FCM 토큰 등록 분리

### DIFF
--- a/src/main/java/com/memoryseal/memorysealbackend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/auth/controller/AuthController.java
@@ -97,7 +97,7 @@ public class AuthController {
             @RequestBody GoogleLoginRequest request
             ) {
         String providerId = loginService.verifyGoogleIdToken(request.getIdToken());
-        GeneratedToken response = loginService.execute(providerId, "google", request.getFcmToken());
+        GeneratedToken response = loginService.execute(providerId, "google");
 
         return ResponseEntity.ok(response);
     }
@@ -110,15 +110,33 @@ public class AuthController {
                     examples = @ExampleObject(value = "{\"status\": \"401\", \"error\": \"INVALID_TOKEN\", \"message\": \"유효하지 않은 토큰입니다.\", \"path\": \"/auth/login/apple\"}"))),
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                    examples = @ExampleObject(value = "{\"status\": \"401\", \"error\": \"USER_NOT_FOUND\", \"message\": \"존재하지 않는 사용자 입니다.\", \"path\": \"/auth/login/apple\"}")))
+                    examples = @ExampleObject(value = "{\"status\": \"404\", \"error\": \"USER_NOT_FOUND\", \"message\": \"존재하지 않는 사용자 입니다.\", \"path\": \"/auth/login/apple\"}")))
     })
     @PostMapping("/login/apple")
     public ResponseEntity<GeneratedToken> loginApple(
             @RequestBody AppleLoginRequest request
     ) {
         String providerId = loginService.verifyAppleIdToken(request.getIdToken(), request.getAuthorizationCode());
-        GeneratedToken response = loginService.execute(providerId, "apple", request.getFcmToken());
+        GeneratedToken response = loginService.execute(providerId, "apple");
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "FCM 토큰 등록")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"status\": \"400\", \"error\": \"INVALID_FCM_TOKEN\", \"message\": \"유효하지 않은 FCM 토큰입니다.\", \"path\": \"/auth/fcm-token\"}"))),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"status\": \"404\", \"error\": \"USER_NOT_FOUND\", \"message\": \"존재하지 않는 사용자 입니다.\", \"path\": \"/auth/fcm-token\"}")))
+    })
+    @PutMapping("/fcm-token")
+    public ResponseEntity<Void> updateFcmToken(
+            @RequestParam String fcmToken
+    ) {
+        loginService.updateFcmToken(fcmToken);
+        return ResponseEntity.ok().build();
     }
 
     /*

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/auth/controller/dto/req/AppleLoginRequest.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/auth/controller/dto/req/AppleLoginRequest.java
@@ -13,7 +13,4 @@ public class AppleLoginRequest {
 
     @Schema(description = "authorizationCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String authorizationCode;
-
-    @Schema(description = "fcmToken")
-    private String fcmToken;
 }

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/auth/controller/dto/req/GoogleLoginRequest.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/auth/controller/dto/req/GoogleLoginRequest.java
@@ -8,7 +8,4 @@ import lombok.Getter;
 public class GoogleLoginRequest {
     @Schema(description = "idToken")
     private String idToken;
-
-    @Schema(description = "fcmToken")
-    private String fcmToken;
 }

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/auth/service/LoginService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/auth/service/LoginService.java
@@ -21,6 +21,8 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
@@ -35,12 +37,26 @@ public class LoginService {
     private final GoogleProperties googleProperties;
     private final AppleAuthClient appleAuthClient;
 
-    /*
-    @Value("${google.client.ids}")
-    private List<String> googleClientIds;
-     */
     @Value("${app.default-image-url}")
     private String defaultProfileUrl;
+
+    private Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if(authentication == null || !authentication.isAuthenticated()) {
+            throw new AuthException(ErrorCode.NEED_LOGIN);
+        }
+        Object principal = authentication.getPrincipal();
+        Long currentUserId;
+        if(principal instanceof User) {
+            currentUserId = ((User) principal).getId();
+        }else if(principal instanceof String) {
+            currentUserId = Long.valueOf((String) principal);
+        }else {
+            log.error("예상치 못한 Principal 타입: {}", principal.getClass().getName());
+            throw new AuthException(ErrorCode.NEED_LOGIN);
+        }
+        return currentUserId;
+    }
 
     @Transactional
     public String verifyGoogleIdToken(String idTokenString) {
@@ -152,14 +168,22 @@ public class LoginService {
         }
     }
 
+    @Transactional
+    public void updateFcmToken(String fcmToken) {
+        if(fcmToken == null || fcmToken.isBlank()) {
+            throw new AuthException(ErrorCode.INVALID_FCM_TOKEN);
+        }
 
-    public GeneratedToken execute(String providerId, String provider, String fcmToken) {
+        Long currentUserId = getCurrentUserId();
+        User user = userJpaRepository.findById(currentUserId)
+                .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
+        user.setFcmToken(fcmToken);
+    }
+
+
+    public GeneratedToken execute(String providerId, String provider) {
         User user = userJpaRepository.findByProviderAndProviderIdAndUserActiveStatus(provider, providerId, true)
                 .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
-
-        if(fcmToken != null) {
-            user.setFcmToken(fcmToken);
-        }
 
         GeneratedToken generatedToken = jwtUtil.generateToken(user.getEmail(), Role.USER.getKey());
 

--- a/src/main/java/com/memoryseal/memorysealbackend/global/error/ErrorCode.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/global/error/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     HOST_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "호스트는 타임캡슐을 나갈 수 없습니다."),
     CANNOT_DELEGATE_TO_SELF(HttpStatus.BAD_REQUEST, "자기 자신에게 호스트를 위임할 수 없습니다."),
     FILE_IDS_REQUIRED(HttpStatus.BAD_REQUEST, "삭제할 파일 ID를 입력하세요."),
+    INVALID_FCM_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 FCM 토큰입니다."),
 
     // 401 UnAuthorized
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),


### PR DESCRIPTION
## 변경 사항
- AppleLoginRequest, GoogleLoginRequest에서 fcmToken 필드 제거
- LoginService에 updateFcmToken 메서드 추가
- PUT /auth/fcm-token API 추가