### PR TITLE
fix: 타임캡슐 오픈 스케쥴러 시간대 및 N+1 문제 수정

### DIFF
--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/scheduler/TimeCapsuleScheduler.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/scheduler/TimeCapsuleScheduler.java
@@ -17,6 +17,8 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -27,7 +29,7 @@ public class TimeCapsuleScheduler {
     private final UserJpaRepository userJpaRepository;
     private final FCMService fcmService;
 
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void sendOpenNotification() {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime startOfDay = now.toLocalDate().atStartOfDay();
@@ -46,11 +48,14 @@ public class TimeCapsuleScheduler {
             List<Contributor> contributors = contributorJpaRepository
                     .findByTimeCapsuleId(capsule.getId());
 
-            contributors.forEach(c -> {
-                User user = userJpaRepository.findById(c.getUserId())
-                        .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
-                fcmService.sendOpenedNotification(user.getFcmToken(), capsule.getTitle(), capsule.getId());
-            });
+            List<Long> userIds = contributors.stream()
+                            .map(Contributor::getUserId)
+                            .toList();
+
+            Map<Long, User> userMap = userJpaRepository.findAllById(userIds).stream()
+                    .collect(Collectors.toMap(User::getId, u -> u));
+            userMap.values().forEach(user ->
+                    fcmService.sendOpenedNotification(user.getFcmToken(),capsule.getTitle(), capsule.getId()));
         });
 
         timeCapsuleJpaRepository.saveAll(capsules);


### PR DESCRIPTION
## 변경 사항
- cron zone Asia/Seoul 추가
- contributor별 user 개별 조회 → IN절 일괄 조회로 N+1 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 타임캡슐 오픈 알림이 한국 표준시(Asia/Seoul) 기준 자정에 정확히 실행되도록 개선했습니다.
  - 여러 참여자에게 발송되는 알림 처리 방식을 개선해 사용자 조회와 알림 전송의 효율성을 높였습니다.
  - 조회 가능한 사용자에게만 알림을 발송하도록 동작이 정리되어, 일부 사용자 정보 문제로 전체 알림 처리가 중단되는 상황을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->