### PR TITLE
feat: 로그아웃 API 추가

### DIFF
--- a/src/main/java/com/memoryseal/memorysealbackend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/auth/controller/AuthController.java
@@ -139,26 +139,18 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
-    /*
-    @Operation(summary = "로그아웃")
+    @Operation(summary = "logout")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"status\": \"401\", \"error\": \"REFRESHTOKEN_NOT_FOUND\", \"message\": \"저장된 리프레시 토큰이 없습니다.\", \"path\": \"/auth/logout\"}"))),
+    })
     @DeleteMapping("/logout")
     public ResponseEntity<Void> logout(
-            @Parameter(description = "현재 유효한 Access Token", required = true)
-            @RequestHeader("Authorization") String authorizationHeader) {
-        if(authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-            return ResponseEntity.badRequest().build();
-        }
-
-        String accessToken = authorizationHeader.substring(7);
-
-        try {
-            refreshTokenService.removeRefreshToken(accessToken);
-            return ResponseEntity.noContent().build();
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        }
+            @RequestHeader("Authorization") String accessToken
+    ) {
+        loginService.logout(accessToken);
+        return ResponseEntity.ok().build();
     }
-     */
 }

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/auth/controller/AuthController.java
@@ -142,9 +142,12 @@ public class AuthController {
     @Operation(summary = "logout")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰",
+            @ApiResponse(responseCode = "404", description = "유효하지 않은 토큰",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
-                    examples = @ExampleObject(value = "{\"status\": \"401\", \"error\": \"REFRESHTOKEN_NOT_FOUND\", \"message\": \"저장된 리프레시 토큰이 없습니다.\", \"path\": \"/auth/logout\"}"))),
+                    examples = @ExampleObject(value = "{\"status\": \"401\", \"error\": \"INVALID_TOKEN\", \"message\": \"유효하지 않은 토큰입니다.\", \"path\": \"/auth/logout\"}"))),
+            @ApiResponse(responseCode = "404", description = "리프레시 토큰을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"status\": \"404\", \"error\": \"REFRESHTOKEN_NOT_FOUND\", \"message\": \"저장된 리프레시 토큰이 없습니다.\", \"path\": \"/auth/logout\"}")))
     })
     @DeleteMapping("/logout")
     public ResponseEntity<Void> logout(

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/auth/service/LoginService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/auth/service/LoginService.java
@@ -25,6 +25,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.HttpClientErrorException;
 
 @Service
@@ -178,6 +179,14 @@ public class LoginService {
         User user = userJpaRepository.findById(currentUserId)
                 .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
         user.setFcmToken(fcmToken);
+    }
+
+    public void logout(String accessToken) {
+        String actualToken = accessToken;
+        if(StringUtils.hasText(accessToken) && actualToken.startsWith("Bearer ")) {
+            actualToken = accessToken.substring(7);
+        }
+        refreshTokenService.removeRefreshToken(accessToken);
     }
 
 

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/auth/service/LoginService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/auth/service/LoginService.java
@@ -183,10 +183,11 @@ public class LoginService {
 
     public void logout(String accessToken) {
         String actualToken = accessToken;
-        if(StringUtils.hasText(accessToken) && actualToken.startsWith("Bearer ")) {
-            actualToken = accessToken.substring(7);
+        if(!StringUtils.hasText(accessToken) || !actualToken.startsWith("Bearer ")) {
+            throw new AuthException(ErrorCode.INVALID_TOKEN);
         }
-        refreshTokenService.removeRefreshToken(accessToken);
+        actualToken = accessToken.substring(7);
+        refreshTokenService.removeRefreshToken(actualToken);
     }
 
 


### PR DESCRIPTION
## 변경 사항
- DELETE /auth/logout API 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * `/auth/logout` 로그아웃 API가 활성화되었습니다.
  * `Authorization` 헤더의 액세스 토큰으로 로그아웃을 요청할 수 있습니다.
  * 요청 처리 결과와 무관하게 항상 성공 응답(HTTP 200)을 반환합니다.
* **문서**
  * 로그아웃 API의 Swagger 문서와 응답 예시가 최신 동작에 맞게 업데이트되었습니다.
* **개선 사항**
  * `Bearer` 형식의 토큰을 자동으로 반영해 로그아웃 처리가 더 간편해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->