### PR TITLE
feat: 물주기 기능 추가

### DIFF
--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/WateringController.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/WateringController.java
@@ -1,0 +1,37 @@
+package com.memoryseal.memorysealbackend.domain.time_capsule.controller;
+
+import com.memoryseal.memorysealbackend.domain.time_capsule.controller.dto.res.WateringResponseDto;
+import com.memoryseal.memorysealbackend.domain.time_capsule.service.WateringService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/time-capsules")
+@RequiredArgsConstructor
+@Tag(name = "Watering")
+public class WateringController {
+    private final WateringService wateringService;
+
+    @Operation(summary = "물주기")
+    @PostMapping("/{capsuleId}/water")
+    public ResponseEntity<Void> water(@PathVariable Long capsuleId) {
+        wateringService.water(capsuleId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "물주기 현황 조회")
+    @GetMapping("/{capsuleId}/water")
+    public ResponseEntity<WateringResponseDto> getWatering(
+            @PathVariable Long capsuleId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "6") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(wateringService.getWatering(capsuleId, pageable));
+    }
+}

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/WateringDto.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/WateringDto.java
@@ -1,0 +1,16 @@
+package com.memoryseal.memorysealbackend.domain.time_capsule.controller.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class WateringDto {
+    private LocalDate wateredDate;
+    private Boolean isWatered;
+    private Long userId;
+    private String nickname;
+    private String profileImageUrl;
+}

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/WateringResponseDto.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/WateringResponseDto.java
@@ -1,0 +1,14 @@
+package com.memoryseal.memorysealbackend.domain.time_capsule.controller.dto.res;
+
+import com.memoryseal.memorysealbackend.domain.contributor.controller.dto.res.PageResponseDto;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class WateringResponseDto {
+    private long totalDays;
+    private long wateringCount;
+    private int stage;
+    private PageResponseDto<WateringDto> waterings;
+}

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/entity/TimeCapsuleWatering.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/entity/TimeCapsuleWatering.java
@@ -1,0 +1,30 @@
+package com.memoryseal.memorysealbackend.domain.time_capsule.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "tb_time_capsule_watering")
+public class TimeCapsuleWatering {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "time_capsule_id", nullable = false)
+    private Long timeCapsuleId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "watered_date", nullable = false)
+    private LocalDate wateredDate;
+
+}

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/repository/WateringJpaRepository.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/repository/WateringJpaRepository.java
@@ -1,0 +1,15 @@
+package com.memoryseal.memorysealbackend.domain.time_capsule.repository;
+
+import com.memoryseal.memorysealbackend.domain.time_capsule.entity.TimeCapsuleWatering;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface WateringJpaRepository extends JpaRepository<TimeCapsuleWatering, Long> {
+    boolean existsByTimeCapsuleIdAndWateredDate(Long capsuleId, LocalDate wateredDate);
+    List<TimeCapsuleWatering> findByTimeCapsuleId(Long capsuleId);
+    Long countByTimeCapsuleId(Long capsuleId);
+}

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/WateringService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/WateringService.java
@@ -1,0 +1,159 @@
+package com.memoryseal.memorysealbackend.domain.time_capsule.service;
+
+import com.memoryseal.memorysealbackend.domain.contributor.controller.dto.res.PageResponseDto;
+import com.memoryseal.memorysealbackend.domain.contributor.repository.ContributorJpaRepository;
+import com.memoryseal.memorysealbackend.domain.time_capsule.controller.dto.res.WateringDto;
+import com.memoryseal.memorysealbackend.domain.time_capsule.controller.dto.res.WateringResponseDto;
+import com.memoryseal.memorysealbackend.domain.time_capsule.entity.TimeCapsule;
+import com.memoryseal.memorysealbackend.domain.time_capsule.entity.TimeCapsuleStatus;
+import com.memoryseal.memorysealbackend.domain.time_capsule.entity.TimeCapsuleWatering;
+import com.memoryseal.memorysealbackend.domain.time_capsule.repository.TimeCapsuleJpaRepository;
+import com.memoryseal.memorysealbackend.domain.time_capsule.repository.WateringJpaRepository;
+import com.memoryseal.memorysealbackend.domain.user.entity.User;
+import com.memoryseal.memorysealbackend.domain.user.repository.UserJpaRepository;
+import com.memoryseal.memorysealbackend.global.error.ErrorCode;
+import com.memoryseal.memorysealbackend.global.error.Exception.AuthException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WateringService {
+
+    private final TimeCapsuleJpaRepository timeCapsuleJpaRepository;
+    private final UserJpaRepository userJpaRepository;
+    private final WateringJpaRepository wateringJpaRepository;
+    private final ContributorJpaRepository contributorJpaRepository;
+
+    private Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if(authentication == null || !authentication.isAuthenticated()) {
+            throw new AuthException(ErrorCode.NEED_LOGIN);
+        }
+        Object principal = authentication.getPrincipal();
+        Long currentUserId;
+        if(principal instanceof User) {
+            currentUserId = ((User) principal).getId();
+        }else if(principal instanceof String) {
+            currentUserId = Long.valueOf((String) principal);
+        }else {
+            log.error("예상치 못한 Principal 타입: {}", principal.getClass().getName());
+            throw new AuthException(ErrorCode.NEED_LOGIN);
+        }
+        return currentUserId;
+    }
+
+    @Transactional
+    public void water(Long capsuleId) {
+        Long currentUserId = getCurrentUserId();
+
+        TimeCapsule timeCapsule = timeCapsuleJpaRepository.findById(capsuleId)
+                .orElseThrow(() -> new AuthException(ErrorCode.TIMECAPSULE_NOT_FOUND));
+
+        if(timeCapsule.getTimeCapsuleStatus() != TimeCapsuleStatus.BURIED) {
+            throw new AuthException(ErrorCode.NOT_TIMECAPSULE_BURIED);
+        }
+
+        if(!contributorJpaRepository.existsByTimeCapsuleIdAndUserId(capsuleId, currentUserId)) {
+            throw new AuthException(ErrorCode.ACCESS_DENIED);
+        }
+
+        if(wateringJpaRepository.existsByTimeCapsuleIdAndWateredDate(capsuleId, LocalDate.now())) {
+            throw new AuthException(ErrorCode.ALREADY_WATERED);
+        }
+
+        wateringJpaRepository.save(
+                TimeCapsuleWatering.builder()
+                        .timeCapsuleId(capsuleId)
+                        .userId(currentUserId)
+                        .wateredDate(LocalDate.now())
+                        .build());
+    }
+
+    public WateringResponseDto getWatering(Long capsuleId, Pageable pageable) {
+        Long currentUserId = getCurrentUserId();
+
+        TimeCapsule timeCapsule = timeCapsuleJpaRepository.findById(capsuleId)
+                .orElseThrow(() -> new AuthException(ErrorCode.TIMECAPSULE_NOT_FOUND));
+
+        if(!contributorJpaRepository.existsByTimeCapsuleIdAndUserId(capsuleId, currentUserId)) {
+            throw new AuthException(ErrorCode.ACCESS_DENIED);
+        }
+
+        LocalDate buriedDate = timeCapsule.getBuriedAt().toLocalDate();
+        LocalDate openedDate = timeCapsule.getOpenedAt().toLocalDate();
+        long totalDays = ChronoUnit.DAYS.between(buriedDate, openedDate);
+
+        long wateringCount = wateringJpaRepository.countByTimeCapsuleId(capsuleId);
+
+        double percentage = totalDays == 0 ? 0 : (double) wateringCount / totalDays * 100;
+        int stage = Math.min((int) (percentage / 25) + 1, 4);
+
+        List<TimeCapsuleWatering> allWaterings = wateringJpaRepository.findByTimeCapsuleId(capsuleId);
+        Map<LocalDate, TimeCapsuleWatering> wateringMap = allWaterings.stream()
+                .collect(Collectors.toMap(TimeCapsuleWatering::getWateredDate, w -> w));
+
+        List<Long> userIds = allWaterings.stream()
+                .map(TimeCapsuleWatering::getUserId)
+                .distinct()
+                .toList();
+
+        Map<Long, User> userMap = userJpaRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, u -> u));
+
+        LocalDate today = LocalDate.now();
+        LocalDate endDate = today.isBefore(openedDate) ? today : openedDate;
+
+        List<LocalDate> allDates = buriedDate.datesUntil(endDate.plusDays(1))
+                .toList();
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), allDates.size());
+        List<LocalDate> pagedDates = start >= allDates.size() ? List.of() : allDates.subList(start, end);
+
+        List<WateringDto> wateringDtos = pagedDates.stream()
+                .map(date -> {
+                    TimeCapsuleWatering watering = wateringMap.get(date);
+                    if(watering == null) {
+                        return WateringDto.builder()
+                                .wateredDate(date)
+                                .isWatered(false)
+                                .build();
+                    }
+                    User user = userMap.get(watering.getUserId());
+                    return WateringDto.builder()
+                            .wateredDate(date)
+                            .isWatered(true)
+                            .userId(user.getId())
+                            .nickname(user.getNickname())
+                            .profileImageUrl(user.getProfileImage() != null ? user.getProfileImage().getFileUrl() : null)
+                            .build();
+                })
+                .toList();
+
+        Page<WateringDto> page = new PageImpl<>(wateringDtos, pageable, allDates.size());
+
+        return WateringResponseDto.builder()
+                .totalDays(totalDays)
+                .wateringCount(wateringCount)
+                .stage(stage)
+                .waterings(new PageResponseDto<>(page))
+                .build();
+    }
+
+}

--- a/src/main/java/com/memoryseal/memorysealbackend/global/error/ErrorCode.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/global/error/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     CANNOT_DELEGATE_TO_SELF(HttpStatus.BAD_REQUEST, "자기 자신에게 호스트를 위임할 수 없습니다."),
     FILE_IDS_REQUIRED(HttpStatus.BAD_REQUEST, "삭제할 파일 ID를 입력하세요."),
     INVALID_FCM_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 FCM 토큰입니다."),
+    NOT_TIMECAPSULE_BURIED(HttpStatus.BAD_REQUEST, "묻힌 상태의 타임캡슐이 아닙니다."),
 
     // 401 UnAuthorized
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
@@ -46,6 +47,7 @@ public enum ErrorCode {
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
     ALREADY_BURIED(HttpStatus.CONFLICT, "이미 묻힌 타임캡슐입니다."),
     ALREADY_DELETED(HttpStatus.CONFLICT, "이미 삭제되었거나 변경된 데이터입니다."),
+    ALREADY_WATERED(HttpStatus.CONFLICT, "오늘 이미 물을 줬습니다."),
 
     //413 PAYLOAD TOO LARGE
     FILE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "파일 크기가 제한을 초과했습니다."),


### PR DESCRIPTION
## 변경 사항
- 물주기 API 추가
- 물주기 현황 조회 API 추가
- 물주기 현황은 묻은 날부터 오늘까지만 반환
- 물 안 준 날은 isWatered = false로 구분
- 캡슐당 하루 한 번 물주기 제한
- 4단계 성장 단계

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 타임캡슐에 물주기를 등록하고 일별 물주기 현황을 조회할 수 있습니다.
  - 물주기 횟수, 진행 단계, 전체 기간 및 사용자 정보를 확인할 수 있습니다.
  - 물주기 현황을 페이지 단위로 조회할 수 있습니다.

- **오류 처리**
  - 묻힌 상태가 아닌 타임캡슐에는 물을 줄 수 없습니다.
  - 하루에 한 번만 물주기가 가능하며, 중복 시 안내 메시지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->