### PR TITLE
fix: JWT에 provider 추가하여 중복 이메일 유저 조회 해결

### DIFF
--- a/src/main/java/com/memoryseal/memorysealbackend/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/auth/entity/RefreshToken.java
@@ -15,7 +15,7 @@ import java.io.Serializable;
 @RedisHash(value = "jwtToken", timeToLive = 60 * 60 * 24 * 14)
 public class RefreshToken implements Serializable {
 
-    // 이메일을 id로 사용
+    // 유저id를 id로 사용
     @Id
     private String id;
 

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/auth/service/LoginService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/auth/service/LoginService.java
@@ -197,7 +197,7 @@ public class LoginService {
 
         GeneratedToken generatedToken = jwtUtil.generateToken(user.getEmail(), Role.USER.getKey(), provider);
 
-        refreshTokenService.saveTokenInfo(user.getEmail(), generatedToken.getRefreshToken(), generatedToken.getAccessToken());
+        refreshTokenService.saveTokenInfo(user.getId(), generatedToken.getRefreshToken(), generatedToken.getAccessToken());
 
         return generatedToken;
     }

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/auth/service/LoginService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/auth/service/LoginService.java
@@ -195,7 +195,7 @@ public class LoginService {
         User user = userJpaRepository.findByProviderAndProviderIdAndUserActiveStatus(provider, providerId, true)
                 .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
 
-        GeneratedToken generatedToken = jwtUtil.generateToken(user.getEmail(), Role.USER.getKey());
+        GeneratedToken generatedToken = jwtUtil.generateToken(user.getEmail(), Role.USER.getKey(), provider);
 
         refreshTokenService.saveTokenInfo(user.getEmail(), generatedToken.getRefreshToken(), generatedToken.getAccessToken());
 

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/auth/service/RefreshTokenService.java
@@ -62,7 +62,8 @@ public class RefreshTokenService {
         }
 
         String userRole = jwtUtil.getRole(actualToken);
-        GeneratedToken newToken = jwtUtil.generateToken(userEmail, userRole);
+        String userProvider = jwtUtil.getProvider(actualToken);
+        GeneratedToken newToken = jwtUtil.generateToken(userEmail, userRole, userProvider);
 
         tokenEntity.updateAccessToken(newToken.getAccessToken());
         tokenEntity.setRefreshToken(newToken.getRefreshToken());

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/auth/service/RefreshTokenService.java
@@ -2,6 +2,8 @@ package com.memoryseal.memorysealbackend.domain.auth.service;
 
 import com.memoryseal.memorysealbackend.domain.auth.entity.RefreshToken;
 import com.memoryseal.memorysealbackend.domain.auth.repository.RefreshTokenRepository;
+import com.memoryseal.memorysealbackend.domain.user.entity.User;
+import com.memoryseal.memorysealbackend.domain.user.repository.UserJpaRepository;
 import com.memoryseal.memorysealbackend.global.error.ErrorCode;
 import com.memoryseal.memorysealbackend.global.error.Exception.AuthException;
 import com.memoryseal.memorysealbackend.global.security.jwt.GeneratedToken;
@@ -17,11 +19,13 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
+    private final UserJpaRepository userJpaRepository;
     private final JwtUtil jwtUtil;
 
     @Transactional
-    public void saveTokenInfo(String email, String refreshToken, String accessToken) {
-        refreshTokenRepository.findById(email)
+    public void saveTokenInfo(Long userId, String refreshToken, String accessToken) {
+        String key = String.valueOf(userId);
+        refreshTokenRepository.findById(key)
                 .ifPresentOrElse(
                         token -> {
                             token.updateAccessToken(accessToken);
@@ -29,7 +33,7 @@ public class RefreshTokenService {
                             refreshTokenRepository.save(token);
                         },
                         () -> {
-                            refreshTokenRepository.save(new RefreshToken(email, accessToken, refreshToken));
+                            refreshTokenRepository.save(new RefreshToken(key, accessToken, refreshToken));
                         }
                 );
     }
@@ -52,9 +56,18 @@ public class RefreshTokenService {
         }
 
         String userEmail = jwtUtil.getUid(actualToken);
+        String userProvider = jwtUtil.getProvider(actualToken);
 
-        RefreshToken tokenEntity = refreshTokenRepository.findById(userEmail)
+        if(userProvider == null) {
+            throw new AuthException(ErrorCode.INVALID_TOKEN);
+        }
+
+        User user = userJpaRepository.findByEmailAndProvider(userEmail, userProvider)
                 .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
+
+        String key = String.valueOf(user.getId());
+        RefreshToken tokenEntity = refreshTokenRepository.findById(key)
+                .orElseThrow(() -> new AuthException(ErrorCode.REFRESHTOKEN_NOT_FOUND));
 
         if(!tokenEntity.getRefreshToken().equals(actualToken)) {
             refreshTokenRepository.delete(tokenEntity);
@@ -62,7 +75,6 @@ public class RefreshTokenService {
         }
 
         String userRole = jwtUtil.getRole(actualToken);
-        String userProvider = jwtUtil.getProvider(actualToken);
         GeneratedToken newToken = jwtUtil.generateToken(userEmail, userRole, userProvider);
 
         tokenEntity.updateAccessToken(newToken.getAccessToken());

--- a/src/main/java/com/memoryseal/memorysealbackend/global/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/global/oauth/handler/OAuth2SuccessHandler.java
@@ -44,7 +44,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         log.info("generate accessToken = {}", token.getAccessToken());
         log.info("generate refreshToken = {}", token.getRefreshToken());
 
-        refreshTokenService.saveTokenInfo(email, token.getRefreshToken(), token.getAccessToken());
+        //refreshTokenService.saveTokenInfo(email, token.getRefreshToken(), token.getAccessToken());
 
         String targetUrl = UriComponentsBuilder.fromUriString("http://43.201.236.253.sslip.io:8080/auth/login/success")
                 //http://localhost:3000/oauth/callback

--- a/src/main/java/com/memoryseal/memorysealbackend/global/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/global/oauth/handler/OAuth2SuccessHandler.java
@@ -33,13 +33,14 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         log.info("OAuth2 attributes: {}", oAuth2User.getAttributes());
 
         String email = oAuth2User.getAttribute("email");
+        String provider = oAuth2User.getAttribute("provider");
 
         String role = oAuth2User.getAuthorities().stream().
                 findFirst()
                 .map(grantedAuthority -> grantedAuthority.getAuthority())
                 .orElse("ROLE_USER");
 
-        GeneratedToken token = jwtUtil.generateToken(email, role);
+        GeneratedToken token = jwtUtil.generateToken(email, role, provider);
         log.info("generate accessToken = {}", token.getAccessToken());
         log.info("generate refreshToken = {}", token.getRefreshToken());
 

--- a/src/main/java/com/memoryseal/memorysealbackend/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/global/security/jwt/JwtUtil.java
@@ -27,24 +27,25 @@ public class JwtUtil {
         this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtProperties.getSecret()));
     }
 
-    public GeneratedToken generateToken(String email, String role) {
+    public GeneratedToken generateToken(String email, String role, String provider) {
         Long now = new Date().getTime();
         Long accessTokenPeriod = 1000L * 60L * 30L;
         //Long refreshTokenPeriod = 1000L * 60L * 60L * 24L * 14;
-        String refreshToken = generateRefreshToken(email, role);
-        String accessToken = generateAccessToken(email, role);
+        String refreshToken = generateRefreshToken(email, role, provider);
+        String accessToken = generateAccessToken(email, role, provider);
         Long accessTokenExpiresIn = now + accessTokenPeriod;
         //Long refreshTokenExpiresIn = now + refreshTokenPeriod;
 
         return new GeneratedToken(accessToken, refreshToken, accessTokenExpiresIn);
     }
 
-    public String generateRefreshToken(String email, String role) {
+    public String generateRefreshToken(String email, String role, String provider) {
         // 토큰의 유효 기간을 밀리초 단위로 설정
         long refreshPeriod = 1000L * 60L * 60L * 24L * 30L;  // 30일
 
         Claims claims = Jwts.claims().setSubject(email);
         claims.put("role", role);
+        claims.put("provider", provider);
 
         Date now = new Date();
 
@@ -56,10 +57,11 @@ public class JwtUtil {
                 .compact();
     }
 
-    public String generateAccessToken(String email, String role) {
+    public String generateAccessToken(String email, String role, String provider) {
         long tokenPeriod = 1000L * 60L * 60L * 24L; // 1일
         Claims claims = Jwts.claims().setSubject(email);
         claims.put("role", role);
+        claims.put("provider", provider);
 
         Date now = new Date();
         return Jwts.builder()
@@ -100,6 +102,15 @@ public class JwtUtil {
                 .parseClaimsJws(token)
                 .getBody()
                 .get("role", String.class);
+    }
+
+    public String getProvider(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("provider", String.class);
     }
 
 

--- a/src/main/java/com/memoryseal/memorysealbackend/global/security/jwt/TokenAuthenticationFilter.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/global/security/jwt/TokenAuthenticationFilter.java
@@ -41,7 +41,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         try {
             if(jwtUtil.verifyToken(token)) {
                 String email = jwtUtil.getUid(token);
-                User findUser = userJpaRepository.findByEmail(email)
+                String provider = jwtUtil.getProvider(token);
+                User findUser = userJpaRepository.findByEmailAndProvider(email, provider)
                         .orElseThrow(() -> new IllegalStateException("사용자를 찾을 수 없습니다."));
                 Authentication auth = getAuthentication(findUser);
                 SecurityContextHolder.getContext().setAuthentication(auth);


### PR DESCRIPTION
## 변경 사항
- generateToken, generateAccessToken, generateRefreshToken에 provider 파라미터 추가
- getProvider 메서드 추가
- reissue 메서드에 provider 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * JWT에 로그인 제공자 정보가 포함되어 토큰 발급과 갱신 과정에서 일관되게 유지됩니다.
  * 토큰 인증 시 이메일과 로그인 제공자 정보를 함께 확인해 사용자 식별이 강화되었습니다.
  * 소셜 로그인 이후 발급되는 액세스 토큰과 리프레시 토큰에도 제공자 정보가 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->