### PR TITLE
feat: 내 타임캡슐 목록 조회 응답에 stage 필드 추가

### DIFF
--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleNameDto.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleNameDto.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @Builder
 @Schema(
         description = "사용자의 타임캡슐 목록 조회시 사용되는 정보 DTO",
-        requiredProperties = {"timeCapsuleId", "title", "openedAt", "mainImageUrl", "timeCapsuleStatus", "role"}
+        requiredProperties = {"timeCapsuleId", "title", "openedAt", "mainImageUrl", "timeCapsuleStatus", "role", "stage"}
 )
 public class TimeCapsuleNameDto {
 

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleNameDto.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleNameDto.java
@@ -44,4 +44,7 @@ public class TimeCapsuleNameDto {
 
     @Schema(description = "공동작업자 역할", examples = {"HOST", "CONTRIBUTOR"})
     private ContributorRole role;
+
+    @Schema(description = "물주기 단계")
+    private int stage;
 }

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/repository/WateringJpaRepository.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/repository/WateringJpaRepository.java
@@ -2,6 +2,8 @@ package com.memoryseal.memorysealbackend.domain.time_capsule.repository;
 
 import com.memoryseal.memorysealbackend.domain.time_capsule.entity.TimeCapsuleWatering;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -12,4 +14,6 @@ public interface WateringJpaRepository extends JpaRepository<TimeCapsuleWatering
     boolean existsByTimeCapsuleIdAndWateredDate(Long capsuleId, LocalDate wateredDate);
     List<TimeCapsuleWatering> findByTimeCapsuleId(Long capsuleId);
     Long countByTimeCapsuleId(Long capsuleId);
+    @Query("SELECT w.timeCapsuleId, COUNT(w) FROM TimeCapsuleWatering w WHERE w.timeCapsuleId IN :capsuleIds GROUP BY w.timeCapsuleId")
+    List<Object[]> countByTimeCapsuleIdIn(@Param("capsuleIds") List<Long> capsuleIds);
 }

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/TimeCapsuleService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/TimeCapsuleService.java
@@ -11,6 +11,7 @@ import com.memoryseal.memorysealbackend.domain.time_capsule.entity.TimeCapsuleCo
 import com.memoryseal.memorysealbackend.domain.time_capsule.entity.TimeCapsuleStatus;
 import com.memoryseal.memorysealbackend.domain.time_capsule.repository.ContentJpaRepository;
 import com.memoryseal.memorysealbackend.domain.time_capsule.repository.TimeCapsuleJpaRepository;
+import com.memoryseal.memorysealbackend.domain.time_capsule.repository.WateringJpaRepository;
 import com.memoryseal.memorysealbackend.domain.user.entity.User;
 import com.memoryseal.memorysealbackend.global.aws.service.S3Service;
 import com.memoryseal.memorysealbackend.global.error.ErrorCode;
@@ -25,6 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +41,7 @@ public class TimeCapsuleService {
     private final TimeCapsuleJpaRepository timeCapsuleJpaRepository;
     private final ContributorJpaRepository contributorJpaRepository;
     private final ContentJpaRepository contentJpaRepository;
+    private final WateringJpaRepository wateringJpaRepository;
     private final S3Service s3Service;
 
     private Long getCurrentUserId() {
@@ -146,12 +149,30 @@ public class TimeCapsuleService {
         Map<Long, TimeCapsule> timeCapsuleMap = timeCapsules.stream()
                 .collect(Collectors.toMap(TimeCapsule::getId, t -> t));
 
+        Map<Long, Long> wateringCountMap = wateringJpaRepository.countByTimeCapsuleIdIn(timeCapsuleIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
+
         return contributors.stream()
                 .map(contributor -> {
                     TimeCapsule timeCapsule = timeCapsuleMap.get(contributor.getTimeCapsuleId());
                     if(timeCapsule == null) {
                         throw new AuthException(ErrorCode.TIMECAPSULE_NOT_FOUND);
                     }
+
+                    int stage = 0;
+                    if(timeCapsule.getBuriedAt() != null && timeCapsule.getOpenedAt() != null) {
+                        long totalDays = ChronoUnit.DAYS.between(
+                                timeCapsule.getBuriedAt().toLocalDate(),
+                                timeCapsule.getOpenedAt().toLocalDate()
+                        );
+                        long wateringCount = wateringCountMap.getOrDefault(timeCapsule.getId(), 0L);
+                        double percentage = totalDays == 0 ? 0 : (double) wateringCount / totalDays * 100;
+                        stage = Math.min((int) (percentage / 20) + 1, 5);
+                    }
+
                     return TimeCapsuleNameDto.builder()
                             .timeCapsuleId(timeCapsule.getId())
                             .title(timeCapsule.getTitle())
@@ -160,6 +181,7 @@ public class TimeCapsuleService {
                             .mainImageUrl(timeCapsule.getMainImage().getFileUrl())
                             .timeCapsuleStatus(timeCapsule.getTimeCapsuleStatus())
                             .role(contributor.getContributorRole())
+                            .stage(stage)
                             .build();
                 })
                 .sorted(Comparator.comparing(TimeCapsuleNameDto::getCreatedAt).reversed())


### PR DESCRIPTION
## 변경 사항
- TimeCapsuleNameDto에 stage 필드 추가
- WateringJpaRepository에 countByTimeCapsuleIdIn 쿼리 추가
- BEFOREBURIED 상태 캡슐은 stage=0 반환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 타임 캡슐의 물주기 단계 표시 기능이 추가되었습니다. 캡슐 목록 조회 시 매장일부터 개봉일까지의 기간 대비 물주기 비율에 따라 0~5 단계로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->