### PR TITLE
refactor: FCM 데이터 페이로드 type 키를 action으로 변경

### DIFF
--- a/src/main/java/com/memoryseal/memorysealbackend/global/FCM/FCMService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/global/FCM/FCMService.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 public class FCMService {
     private final FirebaseMessaging firebaseMessaging;
 
-    private void sendNotification(String fcmToken, String title, String body, Long capsuleId, String type) {
+    private void sendNotification(String fcmToken, String title, String body, Long capsuleId, String action) {
         if(fcmToken == null) {
             return;
         }
@@ -26,7 +26,7 @@ public class FCMService {
                             .setBody(body)
                             .build())
                     .putData("capsuleId", String.valueOf(capsuleId))
-                    .putData("type", type)
+                    .putData("action", action)
                     .build();
             firebaseMessaging.send(message);
             log.info("푸시 알림 전송 성공: {}", fcmToken);


### PR DESCRIPTION
## 변경 사항
- FCM putData 키 type → action으로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 푸시 알림 데이터의 구분 항목이 `type`에서 `action`으로 변경되었습니다.
  * 기존 알림 전송 흐름과 예외 처리는 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->