### PR TITLE
Refactor/localdatetime to localdate

### DIFF
--- a/src/main/java/com/memoryseal/memorysealbackend/domain/contributor/controller/ContributorController.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/contributor/controller/ContributorController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -77,7 +78,7 @@ public class ContributorController {
     })
     @PutMapping("/{capsuleId}/bury")
     @Operation(summary = "타임캡슐 묻기")
-    public ResponseEntity<TimeCapsuleResponseDto> agreeBury(@PathVariable Long capsuleId, @RequestBody BuryRequestDto request) {
+    public ResponseEntity<TimeCapsuleResponseDto> agreeBury(@PathVariable Long capsuleId, @Valid @RequestBody BuryRequestDto request) {
         return ResponseEntity.ok(contributorService.buryCapsule(capsuleId, request.getOpenedAt()));
     }
 

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/contributor/controller/dto/req/BuryRequestDto.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/contributor/controller/dto/req/BuryRequestDto.java
@@ -5,12 +5,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 public class BuryRequestDto {
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     @Schema(description = "타임캡슐 열리는 날짜")
-    private LocalDateTime openedAt;
+    private LocalDate openedAt;
 }

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/contributor/controller/dto/req/BuryRequestDto.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/contributor/controller/dto/req/BuryRequestDto.java
@@ -2,6 +2,7 @@ package com.memoryseal.memorysealbackend.domain.contributor.controller.dto.req;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -9,6 +10,7 @@ import java.time.LocalDate;
 
 @Getter
 public class BuryRequestDto {
+    @NotNull(message = "타임캡슐 개봉 날짜는 필수 항목 입니다.")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     @Schema(description = "타임캡슐 열리는 날짜")

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/contributor/service/ContributorService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/contributor/service/ContributorService.java
@@ -149,6 +149,7 @@ public class ContributorService {
                 .title(timeCapsule.getTitle())
                 .description(timeCapsule.getDescription())
                 .createdAt(timeCapsule.getCreatedAt())
+                .buriedAt(timeCapsule.getBuriedAt())
                 .openedAt(timeCapsule.getOpenedAt())
                 .mainImageUrl(timeCapsule.getMainImage().getFileUrl())
                 .timeCapsuleStatus(timeCapsule.getTimeCapsuleStatus())

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/contributor/service/ContributorService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/contributor/service/ContributorService.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -111,13 +112,15 @@ public class ContributorService {
             throw new AuthException(ErrorCode.ACCESS_DENIED);
         }
 
-        if(openedAt.isBefore(LocalDate.now())) {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        if(openedAt.isBefore(today)) {
             throw new AuthException(ErrorCode.INVALID_OPENED_AT);
         }
 
         timeCapsule.setOpenedAt(openedAt);
         timeCapsule.setTimeCapsuleStatus(TimeCapsuleStatus.BURIED);
-        timeCapsule.setBuriedAt(LocalDate.now());
+        timeCapsule.setBuriedAt(today);
 
         List<Contributor> contributors = contributorJpaRepository.findByTimeCapsuleId(capsuleId);
         List<Long> userIds = contributors.stream()

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/contributor/service/ContributorService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/contributor/service/ContributorService.java
@@ -114,7 +114,7 @@ public class ContributorService {
 
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 
-        if(openedAt.isBefore(today)) {
+        if(!openedAt.isAfter(today)) {
             throw new AuthException(ErrorCode.INVALID_OPENED_AT);
         }
 

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/contributor/service/ContributorService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/contributor/service/ContributorService.java
@@ -1,7 +1,6 @@
 package com.memoryseal.memorysealbackend.domain.contributor.service;
 
 import com.memoryseal.memorysealbackend.domain.contributor.controller.dto.res.ContributorResponseDto;
-import com.memoryseal.memorysealbackend.domain.contributor.controller.dto.res.PageResponseDto;
 import com.memoryseal.memorysealbackend.domain.contributor.entity.Contributor;
 import com.memoryseal.memorysealbackend.domain.contributor.entity.ContributorRole;
 import com.memoryseal.memorysealbackend.domain.contributor.repository.ContributorJpaRepository;
@@ -29,7 +28,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -95,7 +94,7 @@ public class ContributorService {
     }
 
     @Transactional
-    public TimeCapsuleResponseDto buryCapsule(Long capsuleId, LocalDateTime openedAt) {
+    public TimeCapsuleResponseDto buryCapsule(Long capsuleId, LocalDate openedAt) {
         Long currentUserId = getCurrentUserId();
 
         TimeCapsule timeCapsule = timeCapsuleJpaRepository.findById(capsuleId)
@@ -112,13 +111,13 @@ public class ContributorService {
             throw new AuthException(ErrorCode.ACCESS_DENIED);
         }
 
-        if(openedAt.isBefore(LocalDateTime.now())) {
+        if(openedAt.isBefore(LocalDate.now())) {
             throw new AuthException(ErrorCode.INVALID_OPENED_AT);
         }
 
         timeCapsule.setOpenedAt(openedAt);
         timeCapsule.setTimeCapsuleStatus(TimeCapsuleStatus.BURIED);
-        timeCapsule.setBuriedAt(LocalDateTime.now());
+        timeCapsule.setBuriedAt(LocalDate.now());
 
         List<Contributor> contributors = contributorJpaRepository.findByTimeCapsuleId(capsuleId);
         List<Long> userIds = contributors.stream()
@@ -139,8 +138,8 @@ public class ContributorService {
                 .count();
 
         int myImageCount = (int) myContents.stream()
-                .flatMap(c -> c.getAttachedFiles().stream())
-                .count();
+                .mapToLong(c -> c.getAttachedFiles().size())
+                .sum();
 
 
         return TimeCapsuleResponseDto.builder()

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleCreateResDto.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleCreateResDto.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -29,9 +30,9 @@ public class TimeCapsuleCreateResDto {
     private String description;
 
     @Schema(description = "타임캡슐 열리는 날짜")
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
-    private LocalDateTime openedAt;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private LocalDate openedAt;
 
     @Schema(description = "타임캡슐 상태", examples = {"OPENED", "BURIED", "BEFOREBURIED"})
     private TimeCapsuleStatus timeCapsuleStatus;

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleNameDto.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleNameDto.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -27,9 +28,9 @@ public class TimeCapsuleNameDto {
     private String title;
 
     @Schema(description = "타임캡슐 열리는 날짜")
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
-    private LocalDateTime openedAt;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private LocalDate openedAt;
 
     @Schema(description = "타임캡슐 생성 날짜")
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleResponseDto.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleResponseDto.java
@@ -11,6 +11,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Builder
@@ -35,14 +36,14 @@ public class TimeCapsuleResponseDto {
     private LocalDateTime createdAt;
 
     @Schema(description = "타임캡슐 묻히는 날짜")
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
-    private LocalDateTime buriedAt;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private LocalDate buriedAt;
 
     @Schema(description = "타임캡슐 열리는 날짜")
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
-    private LocalDateTime openedAt;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private LocalDate openedAt;
 
     @Schema(description = "타임캡슐 대표 이미지 URL")
     private String mainImageUrl;

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleUpdateResDto.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleUpdateResDto.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Schema(
         description = "타임캡슐 정보 수정 응답 DTO",
-        requiredProperties = {"title", "description", "openedAt", "mainImageUrl"}
+        requiredProperties = {"title", "description", "mainImageUrl"}
 )
 public class TimeCapsuleUpdateResDto {
 

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/entity/TimeCapsule.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/entity/TimeCapsule.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,15 +30,15 @@ public class TimeCapsule {
     @Column(name = "description", columnDefinition = "TEXT", nullable = true)
     private String description;
 
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     @Column(name = "buried_at", nullable = true)
-    private LocalDateTime buriedAt;
+    private LocalDate buriedAt;
 
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     @Column(name = "opened_at", nullable = true)
-    private LocalDateTime openedAt;
+    private LocalDate openedAt;
 
     @Column(name = "time_capsule_status", nullable = false)
     private TimeCapsuleStatus timeCapsuleStatus;

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/repository/TimeCapsuleJpaRepository.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/repository/TimeCapsuleJpaRepository.java
@@ -5,6 +5,7 @@ import com.memoryseal.memorysealbackend.domain.time_capsule.entity.TimeCapsuleSt
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -12,9 +13,8 @@ import java.util.List;
 public interface TimeCapsuleJpaRepository extends JpaRepository<TimeCapsule, Long> {
     List<TimeCapsule> findByUserId(Long userId);
 
-    List<TimeCapsule> findByOpenedAtBetweenAndTimeCapsuleStatus(
-            LocalDateTime start,
-            LocalDateTime end,
+    List<TimeCapsule> findByOpenedAtAndTimeCapsuleStatus(
+            LocalDate openedAt,
             TimeCapsuleStatus status
     );
 

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/scheduler/TimeCapsuleScheduler.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/scheduler/TimeCapsuleScheduler.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -31,14 +32,11 @@ public class TimeCapsuleScheduler {
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void sendOpenNotification() {
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime startOfDay = now.toLocalDate().atStartOfDay();
-        LocalDateTime endOfDay = startOfDay.plusDays(1);
+        LocalDate today = LocalDate.now();
 
         List<TimeCapsule> capsules = timeCapsuleJpaRepository
-                .findByOpenedAtBetweenAndTimeCapsuleStatus(
-                        startOfDay,
-                        endOfDay,
+                .findByOpenedAtAndTimeCapsuleStatus(
+                        today,
                         TimeCapsuleStatus.BURIED
                 );
 
@@ -54,6 +52,7 @@ public class TimeCapsuleScheduler {
 
             Map<Long, User> userMap = userJpaRepository.findAllById(userIds).stream()
                     .collect(Collectors.toMap(User::getId, u -> u));
+
             userMap.values().forEach(user ->
                     fcmService.sendOpenedNotification(user.getFcmToken(),capsule.getTitle(), capsule.getId()));
         });

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/TimeCapsuleService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/TimeCapsuleService.java
@@ -118,8 +118,8 @@ public class TimeCapsuleService {
                 .count();
 
         int myImageCount = (int) myContents.stream()
-                .flatMap(c -> c.getAttachedFiles().stream())
-                .count();
+                .mapToLong(c -> c.getAttachedFiles().size())
+                .sum();
 
         return TimeCapsuleResponseDto.builder()
                 .title(timeCapsule.getTitle())
@@ -165,8 +165,8 @@ public class TimeCapsuleService {
                     int stage = 0;
                     if(timeCapsule.getBuriedAt() != null && timeCapsule.getOpenedAt() != null) {
                         long totalDays = ChronoUnit.DAYS.between(
-                                timeCapsule.getBuriedAt().toLocalDate(),
-                                timeCapsule.getOpenedAt().toLocalDate()
+                                timeCapsule.getBuriedAt(),
+                                timeCapsule.getOpenedAt()
                         );
                         long wateringCount = wateringCountMap.getOrDefault(timeCapsule.getId(), 0L);
                         double percentage = totalDays == 0 ? 0 : (double) wateringCount / totalDays * 100;

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/WateringService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/WateringService.java
@@ -95,14 +95,14 @@ public class WateringService {
             throw new AuthException(ErrorCode.ACCESS_DENIED);
         }
 
-        LocalDate buriedDate = timeCapsule.getBuriedAt().toLocalDate();
-        LocalDate openedDate = timeCapsule.getOpenedAt().toLocalDate();
+        LocalDate buriedDate = timeCapsule.getBuriedAt();
+        LocalDate openedDate = timeCapsule.getOpenedAt();
         long totalDays = ChronoUnit.DAYS.between(buriedDate, openedDate);
 
         long wateringCount = wateringJpaRepository.countByTimeCapsuleId(capsuleId);
 
         double percentage = totalDays == 0 ? 0 : (double) wateringCount / totalDays * 100;
-        int stage = Math.min((int) (percentage / 25) + 1, 5);
+        int stage = Math.min((int) (percentage / 20) + 1, 5);
 
         List<TimeCapsuleWatering> allWaterings = wateringJpaRepository.findByTimeCapsuleId(capsuleId);
         Map<LocalDate, TimeCapsuleWatering> wateringMap = allWaterings.stream()


### PR DESCRIPTION
## 변경 사항
- TimeCapsule 엔티티 buriedAt, openedAt LocalDateTime → LocalDate로 변경
- TimeCapsuleResponseDto, TimeCapsuleCreateResDto, TimeCapsuleNameDto, BuryRequestDto 날짜 타입 및 패턴 수정
- ContributorService buryCapsule openedAt, buriedAt LocalDate.now()로 변경
- 스케줄러 findByOpenedAtBetween → findByOpenedAtAndTimeCapsuleStatus로 단순화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 타임캡슐의 개봉일과 매장일 표시 및 입력 형식이 날짜·시간에서 `yyyy-MM-dd` 날짜 전용 형식으로 변경되었습니다.
  * 타임캡슐 조회와 개봉 알림이 날짜 기준으로 처리됩니다.
  * 타임캡슐 수정 시 개봉일 입력이 필수 항목에서 제외되었습니다.

* **개선 사항**
  * 물주기 성장 단계 계산 기준이 조정되었습니다.
  * 첨부 파일 개수와 타임캡슐 기간 계산이 더욱 정확하게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->