### PR TITLE
feat: 물주기 테스트용 API 추가

### DIFF
--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/WateringTestController.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/WateringTestController.java
@@ -1,0 +1,74 @@
+package com.memoryseal.memorysealbackend.domain.time_capsule.controller;
+
+import com.memoryseal.memorysealbackend.domain.time_capsule.controller.dto.res.WateringResponseDto;
+import com.memoryseal.memorysealbackend.domain.time_capsule.entity.TimeCapsuleWatering;
+import com.memoryseal.memorysealbackend.domain.time_capsule.repository.WateringJpaRepository;
+import com.memoryseal.memorysealbackend.domain.time_capsule.service.WateringService;
+import com.memoryseal.memorysealbackend.domain.user.entity.User;
+import com.memoryseal.memorysealbackend.global.error.ErrorCode;
+import com.memoryseal.memorysealbackend.global.error.Exception.AuthException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequestMapping("dev/water")
+@RequiredArgsConstructor
+@Slf4j
+public class WateringTestController {
+
+    private final WateringJpaRepository wateringJpaRepository;
+    private final WateringService wateringService;
+
+    private Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if(authentication == null || !authentication.isAuthenticated()) {
+            throw new AuthException(ErrorCode.NEED_LOGIN);
+        }
+        Object principal = authentication.getPrincipal();
+        Long currentUserId;
+        if(principal instanceof User) {
+            currentUserId = ((User) principal).getId();
+        }else if(principal instanceof String) {
+            currentUserId = Long.valueOf((String) principal);
+        }else {
+            log.error("예상치 못한 Principal 타입: {}", principal.getClass().getName());
+            throw new AuthException(ErrorCode.NEED_LOGIN);
+        }
+        return currentUserId;
+    }
+    @PostMapping("/{capsuleId}/bulk")
+    public ResponseEntity<Void> createBulkWatering(@PathVariable Long capsuleId, @RequestParam int count) {
+        List<TimeCapsuleWatering> waterings = new ArrayList<>();
+        Long currentUserId = getCurrentUserId();
+        for(int i = 0; i < count; i++) {
+            waterings.add(TimeCapsuleWatering.builder()
+                    .timeCapsuleId(capsuleId)
+                    .userId(currentUserId)
+                    .wateredDate(LocalDate.now().plusDays(i))
+                    .build());
+        }
+        wateringJpaRepository.saveAll(waterings);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{capsuleId}")
+    public ResponseEntity<WateringResponseDto> getAllWatering(
+            @PathVariable Long capsuleId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(wateringService.getAllWatering(capsuleId, pageable));
+    }
+
+}

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/WateringService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/WateringService.java
@@ -155,4 +155,72 @@ public class WateringService {
                 .build();
     }
 
+    public WateringResponseDto getAllWatering(Long capsuleId, Pageable pageable) {
+        Long currentUserId = getCurrentUserId();
+
+        TimeCapsule timeCapsule = timeCapsuleJpaRepository.findById(capsuleId)
+                .orElseThrow(() -> new AuthException(ErrorCode.TIMECAPSULE_NOT_FOUND));
+
+        if(!contributorJpaRepository.existsByTimeCapsuleIdAndUserId(capsuleId, currentUserId)) {
+            throw new AuthException(ErrorCode.ACCESS_DENIED);
+        }
+
+        LocalDate buriedDate = timeCapsule.getBuriedAt();
+        LocalDate openedDate = timeCapsule.getOpenedAt();
+        long totalDays = ChronoUnit.DAYS.between(buriedDate, openedDate);
+
+        long wateringCount = wateringJpaRepository.countByTimeCapsuleId(capsuleId);
+
+        double percentage = totalDays == 0 ? 0 : (double) wateringCount / totalDays * 100;
+        int stage = Math.min((int) (percentage / 20) + 1, 5);
+
+        List<TimeCapsuleWatering> allWaterings = wateringJpaRepository.findByTimeCapsuleId(capsuleId);
+        Map<LocalDate, TimeCapsuleWatering> wateringMap = allWaterings.stream()
+                .collect(Collectors.toMap(TimeCapsuleWatering::getWateredDate, w -> w));
+
+        List<Long> userIds = allWaterings.stream()
+                .map(TimeCapsuleWatering::getUserId)
+                .distinct()
+                .toList();
+
+        Map<Long, User> userMap = userJpaRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, u -> u));
+
+
+        List<LocalDate> allDates = buriedDate.datesUntil(openedDate.plusDays(1))
+                .toList();
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), allDates.size());
+        List<LocalDate> pagedDates = start >= allDates.size() ? List.of() : allDates.subList(start, end);
+
+        List<WateringDto> wateringDtos = pagedDates.stream()
+                .map(date -> {
+                    TimeCapsuleWatering watering = wateringMap.get(date);
+                    if(watering == null) {
+                        return WateringDto.builder()
+                                .wateredDate(date)
+                                .isWatered(false)
+                                .build();
+                    }
+                    User user = userMap.get(watering.getUserId());
+                    return WateringDto.builder()
+                            .wateredDate(date)
+                            .isWatered(true)
+                            .userId(user.getId())
+                            .profileImageUrl(user.getProfileImage() != null ? user.getProfileImage().getFileUrl() : null)
+                            .build();
+                })
+                .toList();
+
+        Page<WateringDto> page = new PageImpl<>(wateringDtos, pageable, allDates.size());
+
+        return WateringResponseDto.builder()
+                .totalDays(totalDays)
+                .wateringCount(wateringCount)
+                .stage(stage)
+                .waterings(new PageResponseDto<>(page))
+                .build();
+    }
+
 }

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/WateringService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/WateringService.java
@@ -119,7 +119,7 @@ public class WateringService {
         LocalDate today = LocalDate.now();
         LocalDate endDate = today.isBefore(openedDate) ? today : openedDate;
 
-        List<LocalDate> allDates = buriedDate.datesUntil(endDate.plusDays(1))
+        List<LocalDate> allDates = buriedDate.datesUntil(endDate)
                 .toList();
 
         int start = (int) pageable.getOffset();
@@ -187,7 +187,7 @@ public class WateringService {
                 .collect(Collectors.toMap(User::getId, u -> u));
 
 
-        List<LocalDate> allDates = buriedDate.datesUntil(openedDate.plusDays(1))
+        List<LocalDate> allDates = buriedDate.datesUntil(openedDate)
                 .toList();
 
         int start = (int) pageable.getOffset();


### PR DESCRIPTION
- POST /dev/water/{capsuleId}/bulk - 물주기 대량 생성 API 추가
- GET /dev/water/{capsuleId} - 개봉일까지 전체 물주기 현황 조회 API 추가
- WateringService에 getAllWatering 메서드 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 인증된 사용자가 지정한 타임캡슐에 대해 물주기 데이터를 일괄 생성할 수 있습니다.
  * 타임캡슐의 전체 보관 기간에 대한 물주기 현황을 페이지 단위로 조회할 수 있습니다.
  * 물주기 총량, 진행 단계, 날짜별 내역 및 참여자 프로필 정보를 확인할 수 있습니다.

* **버그 수정**
  * 인증되지 않은 사용자나 유효하지 않은 접근 권한으로 요청할 경우 적절한 인증 오류가 반환됩니다.
  * 존재하지 않거나 접근할 수 없는 타임캡슐에 대한 요청을 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->