### PR TITLE
refactor: TimeCapsule 엔티티 cretedAt, updatedAt LocalDate로 변경

### DIFF
--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleNameDto.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleNameDto.java
@@ -10,7 +10,6 @@ import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -33,9 +32,9 @@ public class TimeCapsuleNameDto {
     private LocalDate openedAt;
 
     @Schema(description = "타임캡슐 생성 날짜")
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
-    private LocalDateTime createdAt;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private LocalDate createdAt;
 
     @Schema(description = "타임캡슐 대표 이미지 URL")
     private String mainImageUrl;

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleResponseDto.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/dto/res/TimeCapsuleResponseDto.java
@@ -2,7 +2,6 @@ package com.memoryseal.memorysealbackend.domain.time_capsule.controller.dto.res;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.memoryseal.memorysealbackend.domain.contributor.entity.ContributorRole;
-import com.memoryseal.memorysealbackend.domain.time_capsule.entity.TimeCapsule;
 import com.memoryseal.memorysealbackend.domain.time_capsule.entity.TimeCapsuleStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -12,7 +11,6 @@ import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Builder
 @Data
@@ -31,9 +29,9 @@ public class TimeCapsuleResponseDto {
     private String description;
 
     @Schema(description = "타임캡슐 생성 날짜")
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
-    private LocalDateTime createdAt;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private LocalDate createdAt;
 
     @Schema(description = "타임캡슐 묻히는 날짜")
     @DateTimeFormat(pattern = "yyyy-MM-dd")

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/entity/TimeCapsule.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/entity/TimeCapsule.java
@@ -7,7 +7,6 @@ import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,15 +42,15 @@ public class TimeCapsule {
     @Column(name = "time_capsule_status", nullable = false)
     private TimeCapsuleStatus timeCapsuleStatus;
 
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
+    private LocalDate createdAt;
 
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
+    private LocalDate updatedAt;
 
     @Column(name = "time_capsule_active_status", nullable = false)
     private Boolean timeCapsuleActiveStatus;

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/TimeCapsuleService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/TimeCapsuleService.java
@@ -25,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
@@ -72,8 +72,8 @@ public class TimeCapsuleService {
                     .title(timeCapsuleCreateDto.getTitle())
                     .description(timeCapsuleCreateDto.getDescription())
                     .timeCapsuleStatus(TimeCapsuleStatus.BEFOREBURIED)
-                    .createdAt(LocalDateTime.now())
-                    .updatedAt(LocalDateTime.now())
+                    .createdAt(LocalDate.now())
+                    .updatedAt(LocalDate.now())
                     .timeCapsuleActiveStatus(true)
                     .userId(currentUserId)
                     .build();
@@ -210,7 +210,7 @@ public class TimeCapsuleService {
             }
         }
 
-        timeCapsule.setUpdatedAt(LocalDateTime.now());
+        timeCapsule.setUpdatedAt(LocalDate.now());
 
         if(mainImage != null && !mainImage.isEmpty()) {
             log.info("이미지 업로드 시도: {}", mainImage.getOriginalFilename());

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/TimeCapsuleService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/TimeCapsuleService.java
@@ -68,12 +68,13 @@ public class TimeCapsuleService {
         log.info("타임캡슐 생성 시작 - 유저 ID: {}", currentUserId);
 
         try{
+            LocalDate today = LocalDate.now();
             TimeCapsule timeCapsule = TimeCapsule.builder()
                     .title(timeCapsuleCreateDto.getTitle())
                     .description(timeCapsuleCreateDto.getDescription())
                     .timeCapsuleStatus(TimeCapsuleStatus.BEFOREBURIED)
-                    .createdAt(LocalDate.now())
-                    .updatedAt(LocalDate.now())
+                    .createdAt(today)
+                    .updatedAt(today)
                     .timeCapsuleActiveStatus(true)
                     .userId(currentUserId)
                     .build();


### PR DESCRIPTION
## 변경 사항
- TimeCapsule 엔티티 createdAt, updatedAt LocalDateTime → LocalDate로 변경
- TimeCapsuleResponseDto, TimeCapsuleNameDto 날짜 타입 및 패턴 수정
- TimeCapsuleService openedAt, buriedAt LocalDate.now()로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 타임캡슐의 생성일과 수정일이 시간 정보를 제외한 날짜 단위로 표시됩니다.
  * 날짜 형식이 `yyyy-MM-dd`로 통일되어 더 간결하게 제공됩니다.
  * 타임캡슐 생성 및 수정 시 날짜가 현재 날짜 기준으로 기록됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->