### PR TITLE
fix: 물주기 현황 조회 날짜 범위 수정

### DIFF
--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/WateringService.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/service/WateringService.java
@@ -117,13 +117,13 @@ public class WateringService {
                 .collect(Collectors.toMap(User::getId, u -> u));
 
         LocalDate today = LocalDate.now();
-        LocalDate endDate = today.isBefore(openedDate) ? today : openedDate;
+        LocalDate endDate = today.isBefore(openedDate) ? today : openedDate.minusDays(1);
 
         List<LocalDate> allDates;
         if("asc".equalsIgnoreCase(sort)) {
-            allDates = buriedDate.datesUntil(endDate).toList();
+            allDates = buriedDate.datesUntil(endDate.plusDays(1)).toList();
         }else if ("desc".equalsIgnoreCase(sort)) {
-            allDates = buriedDate.datesUntil(endDate)
+            allDates = buriedDate.datesUntil(endDate.plusDays(1))
                     .sorted(Comparator.reverseOrder())
                     .toList();
         }else {


### PR DESCRIPTION
## 변경 사항
- 오늘 날짜 미포함 버그 수정
- 개봉일 제외 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 캡슐 종료일이 현재 날짜에 도달했거나 지난 경우에도 날짜 목록에 해당 종료일이 포함되도록 수정했습니다.
  * 오름차순과 내림차순 날짜 목록 모두 동일하게 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->