### PR TITLE
fix: String 타입 파싱 예외 처리

### DIFF
--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/MultipartJackson2HttpMessageConverter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
 import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.lang.reflect.Type;
 
@@ -11,6 +12,24 @@ import java.lang.reflect.Type;
 public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
     public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
         super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    // 1. Class 타입 검사 시 String 및 MultipartFile 제외
+    @Override
+    public boolean canRead(Class<?> clazz, MediaType mediaType) {
+        if (clazz.equals(String.class) || MultipartFile.class.isAssignableFrom(clazz)) {
+            return false;
+        }
+        return super.canRead(clazz, mediaType);
+    }
+
+    // 2. Generic Type 검사 시 String 제외
+    @Override
+    public boolean canRead(Type type, Class<?> contextClass, MediaType mediaType) {
+        if (type.equals(String.class)) {
+            return false;
+        }
+        return super.canRead(type, contextClass, mediaType);
     }
 
     @Override

--- a/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/TimeCapsuleContentController.java
+++ b/src/main/java/com/memoryseal/memorysealbackend/domain/time_capsule/controller/TimeCapsuleContentController.java
@@ -34,7 +34,7 @@ public class TimeCapsuleContentController {
     private final TimeCapsuleContentService timeCapsuleContentService;
 
     @PostMapping(value = "/{timeCapsuleId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    @Operation(summary = "타임캡슐 내용 생성", requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = false))
+    @Operation(summary = "타임캡슐 내용 생성")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "성공"),
             @ApiResponse(responseCode = "400", description = "1. 내용 또는 파일 중 적어도 하나는 포함되어야 함 \t\n 2. 지원하지 않는 파일 형식 \t\n 3. 업로드할 파일이 없음",


### PR DESCRIPTION
## 변경 사항
- Swagger/Multipart 요청 시 String(content) 파트가 Jackson 파서로 유입되어 발생하던 Invalid UTF-8 start byte (0x9d/0x9a) 에러 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 파일 업로드가 포함된 요청을 보다 정확하게 처리하도록 개선했습니다.
  * 문자열 및 파일 데이터가 부적절한 방식으로 해석되는 문제를 방지했습니다.

* **문서**
  * 콘텐츠 생성 API의 Swagger 설명을 간결하게 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->